### PR TITLE
Sets assemblaDescription envvar to an empty string when no description was provided

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/assembla/AssemblaBuildTrigger.java
+++ b/src/main/java/org/jenkinsci/plugins/assembla/AssemblaBuildTrigger.java
@@ -232,8 +232,15 @@ public class AssemblaBuildTrigger extends Trigger<AbstractProject<?, ?>> {
         values.put("assemblaSourceSpaceId", new StringParameterValue("assemblaSourceSpaceId", cause.getSourceSpaceId()));
         values.put("assemblaSourceRepositoryUrl", new StringParameterValue("assemblaSourceRepositoryUrl", cause.getSourceRepositoryUrl()));
         values.put("assemblaSourceBranch", new StringParameterValue("assemblaSourceBranch", cause.getSourceBranch()));
-        values.put("assemblaDescription", new StringParameterValue("assemblaDescription", cause.getDescription()));
         values.put("assemblaAuthorName", new StringParameterValue("assemblaAuthorName", cause.getAuthorName()));
+
+        // The merge request description will be null if no description was entered
+        String description = cause.getDescription();
+        if (description == null) {
+            values.put("assemblaDescription", new StringParameterValue("assemblaDescription", ""));
+        } else {
+            values.put("assemblaDescription", new StringParameterValue("assemblaDescription", description));
+        }
 
         return values;
     }

--- a/src/test/java/org/jenkinsci/plugins/assembla/AssemblaBuildTriggerTest.java
+++ b/src/test/java/org/jenkinsci/plugins/assembla/AssemblaBuildTriggerTest.java
@@ -3,6 +3,7 @@ package org.jenkinsci.plugins.assembla;
 import hudson.model.AbstractProject;
 import hudson.model.FreeStyleProject;
 import hudson.model.ParametersAction;
+import hudson.model.ParameterValue;
 import org.jenkinsci.plugins.assembla.api.AssemblaClient;
 import org.jenkinsci.plugins.assembla.api.models.SpaceTool;
 import org.jenkinsci.plugins.assembla.cause.AssemblaMergeRequestCause;
@@ -11,6 +12,7 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
+import org.mockito.ArgumentCaptor;
 
 import java.util.Set;
 
@@ -63,6 +65,19 @@ public class AssemblaBuildTriggerTest {
         AssemblaMergeRequestCause mrCause = AssemblaTestUtil.getMergeRequestCause();
         trigger.handleMergeRequest(mrCause);
         verify(project, times(1)).scheduleBuild2(eq(0), eq(mrCause), any(ParametersAction.class));
+    }
+
+    @Test
+    public void testHandleMergeRequestWithoutDescription() throws Exception {
+        project = spy(project);
+        trigger.start(project, true);
+        AssemblaMergeRequestCause mrCause = AssemblaTestUtil.getMergeRequestCauseWithoutDescription();
+        trigger.handleMergeRequest(mrCause);
+
+        ArgumentCaptor<ParametersAction> argument = ArgumentCaptor.forClass(ParametersAction.class);
+        verify(project, times(1)).scheduleBuild2(eq(0), eq(mrCause), argument.capture());
+        ParameterValue descriptionValue = argument.getValue().getParameter("assemblaDescription");
+        assertEquals("", descriptionValue.getValue());
     }
 
     @Test

--- a/src/test/java/org/jenkinsci/plugins/assembla/AssemblaTestUtil.java
+++ b/src/test/java/org/jenkinsci/plugins/assembla/AssemblaTestUtil.java
@@ -107,6 +107,22 @@ public class AssemblaTestUtil {
             "Author"
         );
     }
+    
+    public static AssemblaMergeRequestCause getMergeRequestCauseWithoutDescription() {
+        return new AssemblaMergeRequestCause(
+            12345,
+            "git@git.assembla.com:pavel-fork.git",
+            "git",
+            "develop",
+            "git@git.assembla.com:pavel-test.git",
+            "master",
+            "276dc190d87eff3d28fdfad2d1e6a08a672efe13",
+            null,
+            "12345",
+            "Redirect all old catalog pages to assembla.com/home",
+            "Author"
+        );
+    }
 
     @SuppressWarnings("unchecked")
     private static void setupReq() {


### PR DESCRIPTION
If the description field was left empty, the environment variable was set to null which causes an IllegalArgumentException when running the project.
