### PR TITLE
Reopening a merge request should trigger build

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/assembla/WebhookPayload.java
+++ b/src/main/java/org/jenkinsci/plugins/assembla/WebhookPayload.java
@@ -143,7 +143,7 @@ public class WebhookPayload {
     }
 
     public boolean shouldTriggerBuild() {
-        return isChangesetEvent() || (isMergeRequestEvent() && (action.equals("updated") || action.equals("created")));
+        return isChangesetEvent() || (isMergeRequestEvent() && (action.equals("updated") || action.equals("created") || action.equals("reopened")));
     }
 
     @Override

--- a/src/test/java/org/jenkinsci/plugins/assembla/WebhookPayloadTest.java
+++ b/src/test/java/org/jenkinsci/plugins/assembla/WebhookPayloadTest.java
@@ -64,4 +64,20 @@ public class WebhookPayloadTest {
     public void testGetSpaceWikiName() throws Exception {
         assertEquals(payload.getSpaceWikiName(), "pavel-test");
     }
+
+    @Test
+    public void testReopenShouldTriggerBuild() throws Exception {
+        WebhookPayload reopenPayload = new WebhookPayload(
+                "pavel test",
+                "reopened",
+                "Merge request",
+                "Merge Request 2945043: Redirect all old catalog pages to assembla.com/home",
+                "Pavel Dotsulenko (pavel.d) updated Merge Request 2945043 (6): Redirect all old catalog pages to assembla.com/home [+0] [-0]\\n\\n    New Version (6) Created\\n",
+                "pavel.d",
+                "master",
+                "git@git.assembla.com:pavel-test.2.git",
+                "276dc190d87eff3d28fdfad2d1e6a08a672efe13"
+        );
+        assertTrue(reopenPayload.shouldTriggerBuild());
+    }
 }


### PR DESCRIPTION
The branch can change between the merge request being ignored and reopened. This is also a nice way to retry a build that failed.
