### PR TITLE
[JENKINS-42377] Added support for TokenMacro

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,6 +31,11 @@
       <artifactId>git</artifactId>
       <version>2.2.4</version>
     </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>token-macro</artifactId>
+      <version>2.0</version>
+    </dependency>
     <!-- JMockit's dependency must be declared before that of JUnit. -->
     <dependency>
       <groupId>org.jmockit</groupId>

--- a/src/main/java/org/jenkinsci/plugins/assembla/AssemblaBuildReporter.java
+++ b/src/main/java/org/jenkinsci/plugins/assembla/AssemblaBuildReporter.java
@@ -11,6 +11,7 @@ import org.jenkinsci.plugins.assembla.api.models.MergeRequest;
 import org.jenkinsci.plugins.assembla.api.models.MergeRequestVersion;
 import org.jenkinsci.plugins.assembla.api.models.Ticket;
 import org.jenkinsci.plugins.assembla.cause.AssemblaMergeRequestCause;
+import org.jenkinsci.plugins.tokenmacro.TokenMacro;
 
 import java.io.IOException;
 import java.util.HashMap;
@@ -155,9 +156,7 @@ public class AssemblaBuildReporter {
         String returnString = inputString;
         if (build != null && inputString != null) {
             try {
-                Map<String, String> messageEnvVars = getEnvVars(build, listener);
-
-                returnString = Util.replaceMacro(inputString, messageEnvVars);
+                returnString = TokenMacro.expandAll(build, listener, inputString);
 
             } catch (Exception e) {
                 LOGGER.log(Level.SEVERE, "Couldn't replace macros in message: ", e);

--- a/src/main/webapp/help-buildTemplateVariables.html
+++ b/src/main/webapp/help-buildTemplateVariables.html
@@ -1,4 +1,5 @@
-<p>You can use any env variables or build parameters, additionally plugin provides the following variables:</p>
+<p>You can use environment variables, build parameters, or a variable expanded by the <a href="https://wiki.jenkins-ci.org/display/JENKINS/Token+Macro+Plugin" target="_blank">token macro plugin</a>.</p>
+<p>Additionally, the following variables are also available:</p>
 <ul>
     <li><b>$mrTitle</b> - merge request title</li>
     <li><b>$mrAbbrTitle</b> - merge request title truncated to 30 chars</li>

--- a/src/test/java/org/jenkinsci/plugins/assembla/AssemblaTestUtil.java
+++ b/src/test/java/org/jenkinsci/plugins/assembla/AssemblaTestUtil.java
@@ -76,7 +76,7 @@ public class AssemblaTestUtil {
     }
 
     public static AssemblaBuildTrigger getTrigger() throws Exception {
-        return new AssemblaBuildTrigger("space-name", "git", true, true, true, true, true, "master", "", "", "");
+        return new AssemblaBuildTrigger("space-name", "git", true, true, true, true, true, "master", "", "$jobName #$BUILD_NUMBER build started", "$jobName #$BUILD_NUMBER build finished with status: $buildStatus");
     }
 
     public static AssemblaPushCause getPushCause() {


### PR DESCRIPTION
This adds support for the [Token Macro Plugin](https://wiki.jenkins-ci.org/display/JENKINS/Token+Macro+Plugin) ([JENKINS-42377](https://issues.jenkins-ci.org/browse/JENKINS-42377)). Merge request comments, ticket comments, and job descriptions may now use tokens provided by other plugins (e.g. warnings or open tasks).

![example](https://cloud.githubusercontent.com/assets/480718/23584068/c41fc8b2-011b-11e7-8144-6b817bb8be91.png)

The one drawback is that this change will create a dependency on the Token Macro Plugin.