### PR TITLE
Adds options to trigger a job when a merge request is closed

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/assembla/AssemblaBuildTrigger.java
+++ b/src/main/java/org/jenkinsci/plugins/assembla/AssemblaBuildTrigger.java
@@ -256,9 +256,11 @@ public class AssemblaBuildTrigger extends Trigger<AbstractProject<?, ?>> {
     private Boolean shouldMergeRequestTriggerBuild(AssemblaMergeRequestCause cause) {
         if ((cause.isCreated() || cause.isUpdated()) && buildOnMergeRequestEnabled) {
             return true;
-        } else if (cause.isMerged() && buildOnMergeRequestMergedEnabled) {
+        }
+        if (cause.isMerged() && buildOnMergeRequestMergedEnabled) {
             return true;
-        } else if (cause.isIgnored() && buildOnMergeRequestIgnoredEnabled) {
+        }
+        if (cause.isIgnored() && buildOnMergeRequestIgnoredEnabled) {
             return true;
         }
 

--- a/src/main/java/org/jenkinsci/plugins/assembla/AssemblaBuildTrigger.java
+++ b/src/main/java/org/jenkinsci/plugins/assembla/AssemblaBuildTrigger.java
@@ -51,6 +51,9 @@ public class AssemblaBuildTrigger extends Trigger<AbstractProject<?, ?>> {
     private boolean ticketCommentsEnabled;
     private boolean notifyOnStartEnabled;
 
+    private boolean buildOnMergeRequestMergedEnabled;
+    private boolean buildOnMergeRequestIgnoredEnabled;
+
     private boolean triggerOnPushEnabled;
 
     private String branchesToBuild;
@@ -63,6 +66,8 @@ public class AssemblaBuildTrigger extends Trigger<AbstractProject<?, ?>> {
                                 boolean mergeRequestCommentsEnabled,
                                 boolean ticketCommentsEnabled,
                                 boolean notifyOnStartEnabled,
+                                boolean buildOnMergeRequestMergedEnabled,
+                                boolean buildOnMergeRequestIgnoredEnabled,
                                 boolean triggerOnPushEnabled,
                                 String branchesToBuild,
                                 String buildDescriptionTemplate,
@@ -77,6 +82,8 @@ public class AssemblaBuildTrigger extends Trigger<AbstractProject<?, ?>> {
         this.mergeRequestCommentsEnabled = mergeRequestCommentsEnabled;
         this.ticketCommentsEnabled = ticketCommentsEnabled;
         this.notifyOnStartEnabled = notifyOnStartEnabled;
+        this.buildOnMergeRequestMergedEnabled = buildOnMergeRequestMergedEnabled;
+        this.buildOnMergeRequestIgnoredEnabled = buildOnMergeRequestIgnoredEnabled;
         this.triggerOnPushEnabled = triggerOnPushEnabled;
         this.branchesToBuild = branchesToBuild.trim();
     }
@@ -105,9 +112,10 @@ public class AssemblaBuildTrigger extends Trigger<AbstractProject<?, ?>> {
     }
 
     public QueueTaskFuture<?> handleMergeRequest(AssemblaMergeRequestCause cause) {
-        if (!buildOnMergeRequestEnabled) {
+        if (!shouldMergeRequestTriggerBuild(cause)) {
             return null;
         }
+
         Map<String, ParameterValue> values = getDefaultParameters(cause);
 
         values.put("assemblaMergeRequestId", new StringParameterValue("assemblaMergeRequestId", String.valueOf(cause.getMergeRequestId())));
@@ -243,6 +251,18 @@ public class AssemblaBuildTrigger extends Trigger<AbstractProject<?, ?>> {
         }
 
         return values;
+    }
+
+    private Boolean shouldMergeRequestTriggerBuild(AssemblaMergeRequestCause cause) {
+        if ((cause.isCreated() || cause.isUpdated()) && buildOnMergeRequestEnabled) {
+            return true;
+        } else if (cause.isMerged() && buildOnMergeRequestMergedEnabled) {
+            return true;
+        } else if (cause.isIgnored() && buildOnMergeRequestIgnoredEnabled) {
+            return true;
+        }
+
+        return false;
     }
 
     public static final class AssemblaBuildTriggerDescriptor extends TriggerDescriptor {

--- a/src/main/java/org/jenkinsci/plugins/assembla/WebhookPayload.java
+++ b/src/main/java/org/jenkinsci/plugins/assembla/WebhookPayload.java
@@ -149,7 +149,7 @@ public class WebhookPayload {
     }
 
     public boolean shouldTriggerBuild() {
-        return isChangesetEvent() || (isMergeRequestEvent() && (action.equals("updated") || action.equals("created") || action.equals("reopened")));
+        return isChangesetEvent() || isMergeRequestEvent();
     }
 
     @Override

--- a/src/main/java/org/jenkinsci/plugins/assembla/cause/AssemblaMergeRequestCause.java
+++ b/src/main/java/org/jenkinsci/plugins/assembla/cause/AssemblaMergeRequestCause.java
@@ -12,6 +12,7 @@ public class AssemblaMergeRequestCause extends AssemblaCause {
     private final Integer mergeRequestId;
     private final String targetBranch;
     private final String targetRepositoryUrl;
+    private final String action;
 
     public Integer getMergeRequestId() {
         return mergeRequestId;
@@ -31,7 +32,8 @@ public class AssemblaMergeRequestCause extends AssemblaCause {
                                      String description,
                                      String sourceSpaceId,
                                      String title,
-                                     String author) {
+                                     String author,
+                                     String action) {
         super(
             sourceRepositoryUrl,
             sourceRepositoryName,
@@ -46,7 +48,7 @@ public class AssemblaMergeRequestCause extends AssemblaCause {
         this.targetBranch = targetBranch;
         this.mergeRequestId = mergeRequestId;
         this.targetRepositoryUrl = targetRepositoryUrl;
-
+        this.action = action;
     }
 
     public String getAbbreviatedTitle() {
@@ -55,6 +57,22 @@ public class AssemblaMergeRequestCause extends AssemblaCause {
 
     public String getTargetRepositoryUrl() {
         return targetRepositoryUrl;
+    }
+
+    public Boolean isCreated() {
+        return action.equals("created");
+    }
+
+    public Boolean isUpdated() {
+        return action.equals("updated") || action.equals("reopened");
+    }
+
+    public Boolean isMerged() {
+        return action.equals("merged");
+    }
+
+    public Boolean isIgnored() {
+        return action.equals("ignored");
     }
 
     @Override
@@ -88,7 +106,8 @@ public class AssemblaMergeRequestCause extends AssemblaCause {
                 mr.getDescription(),
                 mr.getTargetSpaceId(),
                 mr.getTitle(),
-                payload.getAuthor()
+                payload.getAuthor(),
+                payload.getAction()
         );
     }
 

--- a/src/main/resources/org/jenkinsci/plugins/assembla/AssemblaBuildTrigger/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/assembla/AssemblaBuildTrigger/config.jelly
@@ -39,6 +39,17 @@
           <f:checkbox />
         </f:entry>
     </f:optionalBlock>
+
+    <f:entry title="Build when merge request is merged" field="buildOnMergeRequestMergedEnabled"
+      description="Trigger build after merge request is merged">
+      <f:checkbox />
+    </f:entry>
+
+    <f:entry title="Build when merge request is ignored" field="buildOnMergeRequestIgnoredEnabled"
+      description="Trigger build after merge request is ignored">
+      <f:checkbox />
+    </f:entry>
+
     <f:optionalBlock field="triggerOnPushEnabled" title="Build on push"
       description="Build when change is pushed to Assembla additionally to merge request trigger" inline="true">
       <f:entry field="branchesToBuild" title="Branches to build"

--- a/src/test/java/org/jenkinsci/plugins/assembla/AssemblaTestUtil.java
+++ b/src/test/java/org/jenkinsci/plugins/assembla/AssemblaTestUtil.java
@@ -75,8 +75,42 @@ public class AssemblaTestUtil {
 
     }
 
+    public static AssemblaBuildTrigger getMRMergedTrigger() throws Exception {
+        return new AssemblaBuildTrigger(
+                "space-name",
+                "git",
+                false,
+                false,
+                false,
+                false,
+                true,
+                false,
+                false,
+                "master",
+                "",
+                "$jobName #$BUILD_NUMBER build started",
+                "$jobName #$BUILD_NUMBER build finished with status: $buildStatus");
+    }
+
+    public static AssemblaBuildTrigger getMRIgnoredTrigger() throws Exception {
+        return new AssemblaBuildTrigger(
+                "space-name",
+                "git",
+                false,
+                false,
+                false,
+                false,
+                false,
+                true,
+                false,
+                "master",
+                "",
+                "$jobName #$BUILD_NUMBER build started",
+                "$jobName #$BUILD_NUMBER build finished with status: $buildStatus");
+    }
+
     public static AssemblaBuildTrigger getTrigger() throws Exception {
-        return new AssemblaBuildTrigger("space-name", "git", true, true, true, true, true, "master", "", "$jobName #$BUILD_NUMBER build started", "$jobName #$BUILD_NUMBER build finished with status: $buildStatus");
+        return new AssemblaBuildTrigger("space-name", "git", true, true, true, true, false, false, true, "master", "", "$jobName #$BUILD_NUMBER build started", "$jobName #$BUILD_NUMBER build finished with status: $buildStatus");
     }
 
     public static AssemblaPushCause getPushCause() {
@@ -93,6 +127,10 @@ public class AssemblaTestUtil {
     }
 
     public static AssemblaMergeRequestCause getMergeRequestCause() {
+        return getMergeRequestCause("created");
+    }
+
+    public static AssemblaMergeRequestCause getMergeRequestCause(String action) {
         return new AssemblaMergeRequestCause(
             12345,
             "git@git.assembla.com:pavel-fork.git",
@@ -104,7 +142,8 @@ public class AssemblaTestUtil {
             "Description",
             "12345",
             "Redirect all old catalog pages to assembla.com/home",
-            "Author"
+            "Author",
+            action
         );
     }
     
@@ -120,7 +159,8 @@ public class AssemblaTestUtil {
             null,
             "12345",
             "Redirect all old catalog pages to assembla.com/home",
-            "Author"
+            "Author",
+            "created"
         );
     }
 

--- a/src/test/java/org/jenkinsci/plugins/assembla/WebhookPayloadTest.java
+++ b/src/test/java/org/jenkinsci/plugins/assembla/WebhookPayloadTest.java
@@ -132,4 +132,36 @@ public class WebhookPayloadTest {
         );
         assertTrue(reopenPayload.shouldTriggerBuild());
     }
+
+    @Test
+    public void testMergedShouldTriggerBuild() throws Exception {
+        WebhookPayload payload = new WebhookPayload(
+                "pavel test",
+                "merged",
+                "Merge request",
+                "Merge Request 2945043: Redirect all old catalog pages to assembla.com/home",
+                "Pavel Dotsulenko (pavel.d) updated Merge Request 2945043 (6): Redirect all old catalog pages to assembla.com/home [+0] [-0]\\n\\n    New Version (6) Created\\n",
+                "pavel.d",
+                "master",
+                "git@git.assembla.com:pavel-test.2.git",
+                "276dc190d87eff3d28fdfad2d1e6a08a672efe13"
+        );
+        assertTrue(payload.shouldTriggerBuild());
+    }
+
+    @Test
+    public void testIgnoredShouldTriggerBuild() throws Exception {
+        WebhookPayload payload = new WebhookPayload(
+                "pavel test",
+                "ignored",
+                "Merge request",
+                "Merge Request 2945043: Redirect all old catalog pages to assembla.com/home",
+                "Pavel Dotsulenko (pavel.d) updated Merge Request 2945043 (6): Redirect all old catalog pages to assembla.com/home [+0] [-0]\\n\\n    New Version (6) Created\\n",
+                "pavel.d",
+                "master",
+                "git@git.assembla.com:pavel-test.2.git",
+                "276dc190d87eff3d28fdfad2d1e6a08a672efe13"
+        );
+        assertTrue(payload.shouldTriggerBuild());
+    }
 }


### PR DESCRIPTION
When building a merge request, the job may leave behind artifacts that should be cleared up after the merge request has been merged or ignored. This change adds two new options to the build trigger to enable a job to be triggered when a merge request is merged or ignored.
<img width="542" alt="image" src="https://user-images.githubusercontent.com/480718/50241404-0de69c80-038d-11e9-89e8-db857ddc9b84.png">
